### PR TITLE
tar: fix bug in tar remapping

### DIFF
--- a/tar.bzl
+++ b/tar.bzl
@@ -30,7 +30,7 @@ def remap_tar(name, tar, old_prefix, new_prefix):
             "mkdir temp",
             "cd temp",
             "tar -xf $$CWD/$(location {})".format(tar),
-            "mkdir -p {}".format(new_prefix.rsplit("/", 2)[0]),
+            "mkdir -p {}".format(new_prefix.rsplit("/", 1)[0]),
             "mv {} {}".format(old_prefix, new_prefix),  # map
             "tar -czf $$CWD/$@ `find . -type f`",  # ignore empty directories
         ]),


### PR DESCRIPTION
I should move to skylib paths instead of doing this mess